### PR TITLE
wip: work on local (only password input)

### DIFF
--- a/src/manimulateBrowser.ts
+++ b/src/manimulateBrowser.ts
@@ -28,18 +28,14 @@ export const manimulateBrowser = async ({ page, env }: Props) => {
   await page.type("input[type='password']", env.LOGIN_PASSWORD);
   await page.click(SELECTOR_SUBMIT_BUTTON_PASSWORD);
 
-  // // 8. 生体認証を勧められるので`あとで登録`をクリックする
-  // await page.waitForNavigation({ waitUntil: "networkidle0" });
+  // 8. 生体認証を勧められるので`あとで登録`をクリックする
   // note: ローカル（というか日本語ページ）でしか現れないページのため分ける
   if (process.env.NODE_ENV !== "production") {
+    console.log("[start] skip recommendation biometrics page...");
     const SELECTOR_SUBMIT_PASSKEY_REJECT = "a[data-ga-mfid=passkey_rejected]";
     await page.waitForSelector(SELECTOR_SUBMIT_PASSKEY_REJECT);
     await page.click(SELECTOR_SUBMIT_PASSKEY_REJECT);
   }
-
-  // 9. 画面遷移を待つ
-  // console.log("[start] wait for navigation...");
-  // await page.waitForNavigation({ waitUntil: "networkidle0" });
 
   // 10. 表示を先月に切り替える
   console.log("[start] change view to last month...");

--- a/src/manimulateBrowser.ts
+++ b/src/manimulateBrowser.ts
@@ -19,12 +19,15 @@ export const manimulateBrowser = async ({ page, env }: Props) => {
   await page.waitForSelector("input[type='email']");
   await page.type("input[type='email']", env.LOGIN_EMAIL);
   await page.click("input.submitBtn.homeDomain[type=submit]");
-  await page.waitForNavigation({ waitUntil: "networkidle0" });
+  // await page.waitForNavigation({ waitUntil: "networkidle0" });
 
   // 7. パスワードのインプットボックスにパスワードを入力して次へ
   console.log("[start] input password...");
+  const SELECTOR_SUBMIT_BUTTON_PASSWORD =
+    "input.VwFkbeOc.submitBtn.homeDomain[type=submit]";
+  await page.waitForSelector(SELECTOR_SUBMIT_BUTTON_PASSWORD);
   await page.type("input[type='password']", env.LOGIN_PASSWORD);
-  await page.click("input.VwFkbeOc.submitBtn.homeDomain[type=submit]");
+  await page.click(SELECTOR_SUBMIT_BUTTON_PASSWORD);
 
   // // 8. 生体認証を勧められるので`あとで登録`をクリックする
   // await page.waitForNavigation({ waitUntil: "networkidle0" });

--- a/src/manimulateBrowser.ts
+++ b/src/manimulateBrowser.ts
@@ -19,7 +19,6 @@ export const manimulateBrowser = async ({ page, env }: Props) => {
   await page.waitForSelector("input[type='email']");
   await page.type("input[type='email']", env.LOGIN_EMAIL);
   await page.click("input.submitBtn.homeDomain[type=submit]");
-  // await page.waitForNavigation({ waitUntil: "networkidle0" });
 
   // 7. パスワードのインプットボックスにパスワードを入力して次へ
   console.log("[start] input password...");
@@ -31,11 +30,16 @@ export const manimulateBrowser = async ({ page, env }: Props) => {
 
   // // 8. 生体認証を勧められるので`あとで登録`をクリックする
   // await page.waitForNavigation({ waitUntil: "networkidle0" });
-  // await page.click("a[data-ga-mfid=passkey_rejected]");
+  // note: ローカル（というか日本語ページ）でしか現れないページのため分ける
+  if (process.env.NODE_ENV !== "production") {
+    const SELECTOR_SUBMIT_PASSKEY_REJECT = "a[data-ga-mfid=passkey_rejected]";
+    await page.waitForSelector(SELECTOR_SUBMIT_PASSKEY_REJECT);
+    await page.click(SELECTOR_SUBMIT_PASSKEY_REJECT);
+  }
 
   // 9. 画面遷移を待つ
-  console.log("[start] wait for navigation...");
-  await page.waitForNavigation({ waitUntil: "networkidle0" });
+  // console.log("[start] wait for navigation...");
+  // await page.waitForNavigation({ waitUntil: "networkidle0" });
 
   // 10. 表示を先月に切り替える
   console.log("[start] change view to last month...");


### PR DESCRIPTION
以下原因でローカルで動かない問題をなんとかしたい

### 1. `await page.waitForNavigation({ waitUntil: "networkidle0" });` があるとそこで止まってしまう問題
おそらく原因は画面遷移が速すぎるため。
`waitForSelector` に変えたらローカルでは動いた。Actions上でも動けばこれでよい。

### 2. 生体認証を勧める画面がローカル（というか日本語ページ）でしかはされまれない問題

サイト側がどうやって出し分けているのかわかっていないのでまた今度別PullReqで。