### PR TITLE
artifactをv4にアップデートする

### DIFF
--- a/.github/workflows/run-crawler-production-for-debug.yml
+++ b/.github/workflows/run-crawler-production-for-debug.yml
@@ -39,7 +39,7 @@ jobs:
           INPUT_MONTHS: ${{ github.event.inputs.months }}
       # note: GitHub Actions 上でスクリーンショットを取るための設定
       - name: Download screenshot
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: screenshot


### PR DESCRIPTION
これがないとDebug用のJOBが実行できない:

https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/