### PR TITLE
pupeteerにsandboxを使用しないように指定する

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,6 +19,7 @@ const main = async () => {
 
   const browser = await puppeteer.launch({
     headless: process.env.NODE_ENV === "production" ? true : false,
+    args: ["--no-sandbox", "--disable-setuid-sandbox"],
   });
   const page = await browser.newPage();
   page.setDefaultTimeout(


### PR DESCRIPTION
```
[1841:1841:0208/045611.585129:FATAL:zygote_host_impl_linux.cc(128)] No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor, see https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md. Otherwise see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the (older) SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
[0208/045611.594268:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
[0208/045611.594313:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)
```